### PR TITLE
Fix <picture> usage

### DIFF
--- a/_data/gallery.json
+++ b/_data/gallery.json
@@ -5,12 +5,30 @@
         "img_title": "Terrace with green plants on night street",
         "img_credit": "Photo by Aldiyar Seitkassymov",
         "img_public_url": "https://www.pexels.com/photo/terrace-with-green-plants-on-night-street-3100835/",
-        "ng_large_src": "/images/shop-plants-large.webp 1024w",
-        "ng_med_src": "/images/shop-plants-med.webp 640w",
-        "ng_small_src": "/images/shop-plants-small.webp 320w",
-        "large_src": "/images/shop-plants-large.jpg 1024w",
-        "med_src": "/images/shop-plants-med.jpg 640w",
-        "small_src": "/images/shop-plants-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/shop-plants-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/shop-plants-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/shop-plants-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/shop-plants-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/shop-plants-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/shop-plants-small.jpg",
+            "width": "320"
+        },
         "alt": "Terrace outside shop window with green plants and pink tree on night street"
     },
     {
@@ -19,12 +37,30 @@
         "img_title": "Highway covered in water",
         "img_credit": "Photo by Josh Hild",
         "img_public_url": "https://www.pexels.com/photo/highway-covered-in-water-2524368/",
-        "ng_large_src": "/images/wet-street-large.webp 1024w",
-        "ng_med_src": "/images/wet-street-med.webp 640w",
-        "ng_small_src": "/images/wet-street-small.webp 320w",
-        "large_src": "/images/wet-street-large.jpg 1024w",
-        "med_src": "/images/wet-street-med.jpg 640w",
-        "small_src": "/images/wet-street-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/wet-street-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/wet-street-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/wet-street-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/wet-street-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/wet-street-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/wet-street-small.jpg",
+            "width": "320"
+        },
         "alt": "Skybridge over highway covered in water"
     },
     {
@@ -33,12 +69,30 @@
         "img_title": "Brown painted wall on dim light",
         "img_credit": "Photo by Lukas Hartmann",
         "img_public_url": "https://www.pexels.com/photo/brown-painted-wall-on-dim-light-1055613/",
-        "ng_large_src": "/images/bench-light-large.webp 1024w",
-        "ng_med_src": "/images/bench-light-med.webp 640w",
-        "ng_small_src": "/images/bench-light-small.webp 320w",
-        "large_src": "/images/bench-light-large.jpg 1024w",
-        "med_src": "/images/bench-light-med.jpg 640w",
-        "small_src": "/images/bench-light-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/bench-light-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/bench-light-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/bench-light-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/bench-light-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/bench-light-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/bench-light-small.jpg",
+            "width": "320"
+        },
         "alt": "Brown painted wall with two benches and dim light above"
     },
     {
@@ -47,12 +101,30 @@
         "img_title": "Red light streaks across a street intersection at night",
         "img_credit": "Photo by Jan Kopřiva",
         "img_public_url": "https://www.pexels.com/photo/light-streaks-3290601/",
-        "ng_large_src": "/images/street-flash-large.webp 1024w",
-        "ng_med_src": "/images/street-flash-med.webp 640w",
-        "ng_small_src": "/images/street-flash-small.webp 320w",
-        "large_src": "/images/street-flash-large.jpg 1024w",
-        "med_src": "/images/street-flash-med.jpg 640w",
-        "small_src": "/images/street-flash-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/street-flash-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/street-flash-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/street-flash-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/street-flash-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/street-flash-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/street-flash-small.jpg",
+            "width": "320"
+        },
         "alt": "Red light streaks across a street intersection at night"
     },
     {
@@ -61,12 +133,30 @@
         "img_title": "Abstract architecture black and white boardwalk",
         "img_credit": "Photo by Pixabay",
         "img_public_url": "https://www.pexels.com/photo/abstract-architecture-black-and-white-boardwalk-262367/",
-        "ng_large_src": "/images/boardwalk-large.webp 1024w",
-        "ng_med_src": "/images/boardwalk-med.webp 640w",
-        "ng_small_src": "/images/boardwalk-small.webp 320w",
-        "large_src": "/images/boardwalk-large.jpg 1024w",
-        "med_src": "/images/boardwalk-med.jpg 640w",
-        "small_src": "/images/boardwalk-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/boardwalk-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/boardwalk-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/boardwalk-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/boardwalk-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/boardwalk-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/boardwalk-small.jpg",
+            "width": "320"
+        },
         "alt": "Abstract architecture black and white boardwalk with glass like floor"
     },
     {
@@ -75,12 +165,30 @@
         "img_title": "Person holding glass mason jar with night sky background",
         "img_credit": "Photo by Rakicevic Nenad",
         "img_public_url": "https://www.pexels.com/photo/silhouette-of-person-holding-glass-mason-jar-1274260/",
-        "ng_large_src": "/images/glass-jar-sky-large.webp 1024w",
-        "ng_med_src": "/images/glass-jar-sky-med.webp 640w",
-        "ng_small_src": "/images/glass-jar-sky-large.webp 320w",
-        "large_src": "/images/glass-jar-sky-large.jpg 1024w",
-        "med_src": "/images/glass-jar-sky-med.jpg 640w",
-        "small_src": "/images/glass-jar-sky-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/glass-jar-sky-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/glass-jar-sky-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/glass-jar-sky-large.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/glass-jar-sky-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/glass-jar-sky-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/glass-jar-sky-small.jpg",
+            "width": "320"
+        },
         "alt": "Person holding glass mason jar with night sky background"
     },
     {
@@ -89,12 +197,30 @@
         "img_title": "Radio City Music Hall During Night Time",
         "img_credit": "Photo by Bao Dang",
         "img_public_url": "https://www.pexels.com/photo/radio-city-music-hall-during-night-time-3700369/",
-        "ng_large_src": "/images/radio-city-large.webp 1024w",
-        "ng_med_src": "/images/radio-city-med.webp 640w",
-        "ng_small_src": "/images/radio-city-small.webp 320w",
-        "large_src": "/images/radio-city-large.jpg 1024w",
-        "med_src": "/images/radio-city-med.jpg 640w",
-        "small_src": "/images/radio-city-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/radio-city-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/radio-city-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/radio-city-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/radio-city-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/radio-city-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/radio-city-small.jpg",
+            "width": "320"
+        },
         "alt": "Music hall with bright lights during night time"
     },
     {
@@ -103,12 +229,30 @@
         "img_title": "City Building Office Architecture",
         "img_credit": "Photo by Jayson Marquez",
         "img_public_url": "https://www.pexels.com/photo/city-building-office-architecture-4850412/",
-        "ng_large_src": "/images/city-center-large.webp 1024w",
-        "ng_med_src": "/images/city-center-med.jpg 640w",
-        "ng_small_src": "/images/city-center-small.webp 320w",
-        "large_src": "/images/city-center-large.jpg 1024w",
-        "med_src": "/images/city-center-med.jpg 640w",
-        "small_src": "/images/city-center-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/city-center-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/city-center-med.jpg",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/city-center-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/city-center-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/city-center-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/city-center-small.jpg",
+            "width": "320"
+        },
         "alt": "Tall highrise office building with winding architecture"
     },
     {
@@ -117,12 +261,30 @@
         "img_title": "Buildings during nighttime",
         "img_credit": "Photo by Aleksandar Pasaric",
         "img_public_url": "https://www.pexels.com/photo/photo-of-buildings-during-nighttime-2603464/",
-        "ng_large_src": "/images/highrise-orange-large.webp 1024w",
-        "ng_med_src": "/images/highrise-orange-med.webp 640w",
-        "ng_small_src": "/images/highrise-orange-small.webp 320w",
-        "large_src": "/images/highrise-orange-large.jpg 1024w",
-        "med_src": "/images/highrise-orange-med.jpg 640w",
-        "small_src": "/images/highrise-orange-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/highrise-orange-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/highrise-orange-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/highrise-orange-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/highrise-orange-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/highrise-orange-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/highrise-orange-small.jpg",
+            "width": "320"
+        },
         "alt": "Buildings during nighttime with orange lighting and water below"
     },
     {
@@ -131,12 +293,30 @@
         "img_title": "Water Droplet Digital Wallpaper",
         "img_credit": "Photo by Sourav Mishra",
         "img_public_url": "https://www.pexels.com/photo/water-droplet-digital-wallpaper-1100946/",
-        "ng_large_src": "/images/water-droplet-large.webp 1024w",
-        "ng_med_src": "/images/water-droplet-med.webp 640w",
-        "ng_small_src": "/images/water-droplet-small.webp 320w",
-        "large_src": "/images/water-droplet-large.jpg 1024w",
-        "med_src": "/images/water-droplet-med.jpg 640w",
-        "small_src": "/images/water-droplet-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/water-droplet-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/water-droplet-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/water-droplet-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/water-droplet-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/water-droplet-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/water-droplet-small.jpg",
+            "width": "320"
+        },
         "alt": "Rain drop bursting water particles upwards into the air"
     },
     {
@@ -145,12 +325,30 @@
         "img_title": "Man walking on the empty street",
         "img_credit": "Photo by Marco Trinidad",
         "img_public_url": "https://www.pexels.com/photo/photo-of-empty-road-during-daytime-3295140/",
-        "ng_large_src": "/images/road-fog-large.webp 1024w", 
-        "ng_med_src": "/images/road-fog-med.webp 640w",
-        "ng_small_src": "/images/road-fog-small.webp 320w",
-        "large_src": "/images/road-fog-large.jpg 1024w",
-        "med_src": "/images/road-fog-med.jpg 640w",
-        "small_src": "/images/road-fog-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/road-fog-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/road-fog-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/road-fog-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/road-fog-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/road-fog-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/road-fog-small.jpg",
+            "width": "320"
+        },
         "alt": "An empty road during daytime with fog in the background"
     },
     {
@@ -159,12 +357,30 @@
         "img_title": "Gasoline station during nighttime",
         "img_credit": "Photo by Artem Saranin",
         "img_public_url": "https://www.pexels.com/photo/gasoline-station-during-nighttime-1453781/",
-        "ng_large_src": "/images/gas-station-large.webp 1024w", 
-        "ng_med_src": "/images/gas-station-med.webp 640w",
-        "ng_small_src": "/images/gas-station-small.webp 320w",
-        "large_src": "/images/gas-station-large.jpg 1024w",
-        "med_src": "/images/gas-station-med.jpg 640w",
-        "small_src": "/images/gas-station-small.jpg 320w",
+        "ng_large": {
+            "src": "/images/gas-station-large.webp",
+            "width": "1024"
+        },
+        "ng_med": {
+            "src": "/images/gas-station-med.webp",
+            "width": "640"
+        },
+        "ng_small": {
+            "src": "/images/gas-station-small.webp",
+            "width": "320"
+        },
+        "large": {
+            "src": "/images/gas-station-large.jpg",
+            "width": "1024"
+        },
+        "med": {
+            "src": "/images/gas-station-med.jpg",
+            "width": "640"
+        },
+        "small": {
+            "src": "/images/gas-station-small.jpg",
+            "width": "320"
+        },
         "alt": "Gasoline station during nighttime with glowing red roof lights"
     }
 ]

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -48,7 +48,7 @@
                                             (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
                                             calc(100vw - 2 * 2rem)
                                         ">
-                                <source srcset="{{ imagelarge.src }} {{ imagelarge.width }}w, 
+                                <img srcset="{{ imagelarge.src }} {{ imagelarge.width }}w, 
                                         {{ image.med.src }} {{ image.med.width }}w, 
                                         {{ image.small.src }} {{ image.small.width }}w"
                                         sizes="
@@ -57,8 +57,8 @@
                                             (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
                                             calc(100vw - 2 * 2rem)
                                         "
-                                        type="image/jpg">
-                                <img src="{{ image.small.src }}" alt="{{ image.alt }}">
+                                        src="{{ image.small.src }}"
+                                        alt="{{ image.alt }}">
                             </picture>
                         </a>
                     </div>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -38,19 +38,19 @@
                     <div class="image-container">
                         <a href="/{{ image.name | slug}}/" aria-label="Gallery Image One" rel="noopener">
                             <picture>
-                                <source srcset="{{ image.ng_large_src }}, 
-                                        {{ image.ng_med_src }}, 
-                                        {{ image.ng_small_src }}" 
+                                <source srcset="{{ image.ng_large.src }} {{ image.ng_large.width }}w, 
+                                        {{ image.ng_med.src }} {{ image.ng_med.width }}w, 
+                                        {{ image.ng_small.src }} {{ image.ng_small.width }}w" 
                                         type="image/webp"
                                         sizes="33.3vw, 50vw, 100vw">
-                                <source srcset="{{ imagelarge_src }}, 
-                                        {{ image.med_src }}, 
-                                        {{ image.small_src }}"
+                                <source srcset="{{ imagelarge.src }} {{ imagelarge.width }}w, 
+                                        {{ image.med.src }} {{ image.med.width }}w, 
+                                        {{ image.small.src }} {{ image.small.width }}w"
                                         sizes="33.3vw, 50vw, 100vw"
                                         type="image/jpg">
-                                <source srcset="{{ image.ng_small_src }}" type="image/webp" media="(min-width: 400px)">
-                                <source srcset="{{ image.small_src }}" type="image/jpg" media="(min-width: 400px)">
-                                <img src="{{ image.small_src }}" alt="{{ image.alt }}">
+                                <source srcset="{{ image.ng_small.src }} {{ image.ng_small.width }}w" type="image/webp" media="(min-width: 400px)">
+                                <source srcset="{{ image.small.src }} {{ image.small.width }}w" type="image/jpg" media="(min-width: 400px)">
+                                <img src="{{ image.small.src }}" alt="{{ image.alt }}">
                             </picture>
                         </a>
                     </div>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -38,27 +38,35 @@
                     <div class="image-container">
                         <a href="/{{ image.name | slug}}/" aria-label="Gallery Image One" rel="noopener">
                             <picture>
-                                <source srcset="{{ image.ng_large.src }} {{ image.ng_large.width }}w, 
+                                <source
+                                    type="image/webp"
+                                    srcset="
+                                        {{ image.ng_large.src }} {{ image.ng_large.width }}w, 
                                         {{ image.ng_med.src }} {{ image.ng_med.width }}w, 
-                                        {{ image.ng_small.src }} {{ image.ng_small.width }}w" 
-                                        type="image/webp"
-                                        sizes="
-                                            (min-width: 1100px) calc((1100px - 2 * 2rem - 2 * 3px) / 3),
-                                            (min-width: 934px) calc(100vw - 2 * 2rem - 2 * 3px) / 3),
-                                            (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
-                                            calc(100vw - 2 * 2rem)
-                                        ">
-                                <img srcset="{{ imagelarge.src }} {{ imagelarge.width }}w, 
-                                        {{ image.med.src }} {{ image.med.width }}w, 
-                                        {{ image.small.src }} {{ image.small.width }}w"
-                                        sizes="
-                                            (min-width: 1100px) calc((1100px - 2 * 2rem - 2 * 3px) / 3),
-                                            (min-width: 934px) calc(100vw - 2 * 2rem - 2 * 3px) / 3),
-                                            (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
-                                            calc(100vw - 2 * 2rem)
+                                        {{ image.ng_small.src }} {{ image.ng_small.width }}w
                                         "
-                                        src="{{ image.small.src }}"
-                                        alt="{{ image.alt }}">
+                                    sizes="
+                                        (min-width: 1100px) calc((1100px - 2 * 2rem - 2 * 3px) / 3),
+                                        (min-width: 934px) calc(100vw - 2 * 2rem - 2 * 3px) / 3),
+                                        (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
+                                        calc(100vw - 2 * 2rem)
+                                        "
+                                >
+                                <img
+                                    srcset="
+                                        {{ imagelarge.src }} {{ imagelarge.width }}w, 
+                                        {{ image.med.src }} {{ image.med.width }}w, 
+                                        {{ image.small.src }} {{ image.small.width }}w
+                                        "
+                                    sizes="
+                                        (min-width: 1100px) calc((1100px - 2 * 2rem - 2 * 3px) / 3),
+                                        (min-width: 934px) calc(100vw - 2 * 2rem - 2 * 3px) / 3),
+                                        (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
+                                        calc(100vw - 2 * 2rem)
+                                        "
+                                    src="{{ image.small.src }}"
+                                    alt="{{ image.alt }}"
+                                >
                             </picture>
                         </a>
                     </div>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -58,8 +58,6 @@
                                             calc(100vw - 2 * 2rem)
                                         "
                                         type="image/jpg">
-                                <source srcset="{{ image.ng_small.src }} {{ image.ng_small.width }}w" type="image/webp" media="(min-width: 400px)">
-                                <source srcset="{{ image.small.src }} {{ image.small.width }}w" type="image/jpg" media="(min-width: 400px)">
                                 <img src="{{ image.small.src }}" alt="{{ image.alt }}">
                             </picture>
                         </a>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -42,11 +42,21 @@
                                         {{ image.ng_med.src }} {{ image.ng_med.width }}w, 
                                         {{ image.ng_small.src }} {{ image.ng_small.width }}w" 
                                         type="image/webp"
-                                        sizes="33.3vw, 50vw, 100vw">
+                                        sizes="
+                                            (min-width: 1100px) calc((1100px - 2 * 2rem - 2 * 3px) / 3),
+                                            (min-width: 934px) calc(100vw - 2 * 2rem - 2 * 3px) / 3),
+                                            (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
+                                            calc(100vw - 2 * 2rem)
+                                        ">
                                 <source srcset="{{ imagelarge.src }} {{ imagelarge.width }}w, 
                                         {{ image.med.src }} {{ image.med.width }}w, 
                                         {{ image.small.src }} {{ image.small.width }}w"
-                                        sizes="33.3vw, 50vw, 100vw"
+                                        sizes="
+                                            (min-width: 1100px) calc((1100px - 2 * 2rem - 2 * 3px) / 3),
+                                            (min-width: 934px) calc(100vw - 2 * 2rem - 2 * 3px) / 3),
+                                            (min-width: 643px) calc(100vw - 2 * 2rem - 1 * 3px) / 2),
+                                            calc(100vw - 2 * 2rem)
+                                        "
                                         type="image/jpg">
                                 <source srcset="{{ image.ng_small.src }} {{ image.ng_small.width }}w" type="image/webp" media="(min-width: 400px)">
                                 <source srcset="{{ image.small.src }} {{ image.small.width }}w" type="image/jpg" media="(min-width: 400px)">


### PR DESCRIPTION
Multiple changes, in different commits:
- remove image width from `<img src>`
- fix `sizes` attributes (detailed in [the commit message](https://github.com/tannerdolby/eleventy-stock-gallery/commit/c8ab3f0722ac1f657fdef03954f084f8cd28bf22))
- remove useless `<source>`s
- use `<img>` for the fallback instead of the second `<source>`
- improve code readability

I hope it is simple enough to read and understand. I can explain more if needed.