### PR TITLE
Look in subdirectories of /images

### DIFF
--- a/src/_includes/feature-gallery.njk
+++ b/src/_includes/feature-gallery.njk
@@ -6,7 +6,7 @@
                 <a href="{{ image.title | slug }}" aria-label="Gallery image {{ image.title }}">
                 {% respimg
                     inputDir="./src",
-                    imgDir="/images/",
+                    imgDir=image.imgDir,
                     widths=[320, 480, 640, 1024],
                     sizes="(max-width: 480px) 33.3vw, (min-width: 640px) 50vw, (min-width: 950px) 50vw, 33.3vw",
                     src=image.src,

--- a/src/feature.njk
+++ b/src/feature.njk
@@ -14,7 +14,7 @@ cardType: summary_large_image
             title=image.title,
             desc=image.title + " " + site.pageMetadata.featured.content,
             url=url + "/gallery/" + image.title | slug + "/",
-            img=url + "/images/" + image.src,
+            img=url + image.imgDir + image.src,
             img_alt=image.alt,
             twitter_card_type=cardType,
             twitterHandle=site.author.twitterHandle,


### PR DESCRIPTION
For a large gallery, it can make sense to organize the images into subfolders. So instead of hard-coding the /images/ folder on access, use the one defined in gallery.json